### PR TITLE
Fix typos: Elmbridge, elm, and slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Thanks!
 
-Thanks for taking the time to contribute to Elmbridge. We sincerely appreciate it.
+Thanks for taking the time to contribute to ElmBridge. We sincerely appreciate it.
 
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
 

--- a/Choose Your Own Emoji.md
+++ b/Choose Your Own Emoji.md
@@ -39,9 +39,9 @@ As we did with our last release, let's start first by updating `View.elm` with o
 </section>
 ```
 
-Take a crack at converting this to elm. Some of this is straightforward — we already know how to render static elements with attributes and children using the `Html` module. We also already have a list of all supported emojis in `EmojiConverter.supportedEmojis`. But how will we render all those emojis without a lot of copying and pasting?
+Take a crack at converting this to Elm. Some of this is straightforward — we already know how to render static elements with attributes and children using the `Html` module. We also already have a list of all supported emojis in `EmojiConverter.supportedEmojis`. But how will we render all those emojis without a lot of copying and pasting?
 
-Elm shines in situations like this. Since `View.view` is simply elm code, and `Html.Html` is just another type in elm, we can use normal transformations to produce HTML. We can use `EmojiConverter.supportedEmojis` in combination with the `List` module to convert that list of emojis into a list of HTML elements!
+Elm shines in situations like this. Since `View.view` is simply Elm code, and `Html.Html` is just another type in Elm, we can use normal transformations to produce HTML. We can use `EmojiConverter.supportedEmojis` in combination with the `List` module to convert that list of emojis into a list of HTML elements!
 
 The code in `View.view` can use a helper method to render all emoji keys, like this:
 
@@ -63,9 +63,9 @@ renderKeys =
         (List.map (\emoji -> renderKey emoji) EmojiConverter.supportedEmojis)
 ```
 
-It's worth taking a moment to explain what `List.map` is doing. Much like `Array.prototype.map` in JavaScript, `List.map` takes a function and list, calling the function on each element on the list and returning a list of the produced values. The `(\... -> ...)` syntax is how you define an **anonymous function** in elm.
+It's worth taking a moment to explain what `List.map` is doing. Much like `Array.prototype.map` in JavaScript, `List.map` takes a function and list, calling the function on each element on the list and returning a list of the produced values. The `(\... -> ...)` syntax is how you define an **anonymous function** in Elm.
 
-If you want to learn more, the `List` module is thoroughly documented on [package.elmlang.org](http://package.elm-lang.org/packages/elm-lang/core/latest/List). The site is a great resource if you want to learn more about the public API for available elm packages and core modules.
+If you want to learn more, the `List` module is thoroughly documented on [package.elmlang.org](http://package.elm-lang.org/packages/elm-lang/core/latest/List). The site is a great resource if you want to learn more about the public API for available Elm packages and core modules.
 
 Now, it's your turn! Add the new markup to `View.view`, with the `renderKeys` and `renderKey` helper methods. If you get stuck, you can see [a completed version of this step here](https://github.com/elmbridge/elmoji-translator/releases/tag/release-4-part-1).
 
@@ -134,6 +134,6 @@ And now, for the final step — we need to change our translation key based on t
 
 ![Release 4 part 3](images/release-4-part-3.gif)
 
-You definitely know enough elm to figure this out for yourself. However, if you get stuck, check out [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-4-part-3).
+You definitely know enough Elm to figure this out for yourself. However, if you get stuck, check out [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-4-part-3).
 
-And with that, you've completed your first elm application!
+And with that, you've completed your first Elm application!

--- a/Deployment and Next Steps.md
+++ b/Deployment and Next Steps.md
@@ -1,10 +1,10 @@
 # Deployment and Next Steps
 
-Since elm code compiles to JavaScript, it can be very simple to host and deploy! There are lots of tools out there for hosting static websites composed of HTML, CSS, and JavaScript. For this tutorial, we'll use [Forge](https://getforge.com/), which is free for your first site!
+Since Elm code compiles to JavaScript, it can be very simple to host and deploy! There are lots of tools out there for hosting static websites composed of HTML, CSS, and JavaScript. For this tutorial, we'll use [Forge](https://getforge.com/), which is free for your first site!
 
 ## Goals
 
-  - Deploy your elm application for the world to see!
+  - Deploy your Elm application for the world to see!
   - Learn about what's *not* covered in this tutorial, and how you can learn it
 
 ## Steps
@@ -15,7 +15,7 @@ Deploying a static site on Forge is relatively simple. Just follow these steps:
 
 1. **Create an account at https://getforge.com/.** This should be absolutely free! Once you have an account, follow instructions to create a new, blank site.
 
-2. **Compile your elm application one last time.** This is important! Since Forge only understands compiled JavaScript, any changes you've made to you app after your last compile will not be reflected.
+2. **Compile your Elm application one last time.** This is important! Since Forge only understands compiled JavaScript, any changes you've made to you app after your last compile will not be reflected.
 
 3. **Compress your project's folder into a .zip file.** The exact directions are dependent on your operating system, but it should be relatively straightforward on all platforms.
 
@@ -25,18 +25,18 @@ And voila, you've deployed your Elm application!
 
 ### Next Steps
 
-Thank you for taking the journey with us! Hopefully, you know have an understanding of what it's like to be an elm developer, and what it feels like to work with a functional, compiled language.
+Thank you for taking the journey with us! Hopefully, you know have an understanding of what it's like to be an Elm developer, and what it feels like to work with a functional, compiled language.
 
-Before we finish, we should at least mention the things that this tutorial *didn't* cover, which will come up as you work more in elm. Here's a non-exhuastive list:
+Before we finish, we should at least mention the things that this tutorial *didn't* cover, which will come up as you work more in Elm. Here's a non-exhuastive list:
 
 - **Types and Type Signatures.** Elm allows developers to constrain and document their code using these tools. They are highly encouraged — a well-factored type system makes code more descriptive and more fault tolerant. Once you've learned more about types, some of the more esoteric Elm compiler messages will begin to make more sense as well.
 - **Currying and Piping**. Elm, like many functional languages, allows for functions to partially applied. For example, if a function takes three arguments, you can give it one argument instead — and it will return a new function that takes two arguments! Elm developers use currying to reuse logic accross their applications, and make their code more readable. In combination with the `|>` symbol (a.k.a. the pipe operator), currying can be a powerful tool.
-- **Decoders, Commands, and Subscriptions**. Sometimes, it is necessary for an Elm application to talk to the outside world. You may need to parse JSON sent from your server, make an HTTP request to an API, use a third-party JavaScript library, or manipulate a part of the UI not rendered by your `view` function. In those cases, you will often have to tell elm how to parse data it is receiving by using the `Json.Decode` module. You may also need to listen for changes to the outside world with `Subscriptions` or to trigger events outside of elm using `Commands`.
+- **Decoders, Commands, and Subscriptions**. Sometimes, it is necessary for an Elm application to talk to the outside world. You may need to parse JSON sent from your server, make an HTTP request to an API, use a third-party JavaScript library, or manipulate a part of the UI not rendered by your `view` function. In those cases, you will often have to tell Elm how to parse data it is receiving by using the `Json.Decode` module. You may also need to listen for changes to the outside world with `Subscriptions` or to trigger events outside of Elm using `Commands`.
 
 There's so much to learn! Here are some resources to get you started:
 
-  - [The official elm guide](https://guide.elm-lang.org/) is a great resource, and gives a great rundown of some of the more complicated parts of the language.
-  - [The elm-tutorial project](https://www.gitbook.com/book/sporto/elm-tutorial/details) is an incredibly in-depth tutorial on building a single page app using elm.
-  - [The elm slack group](http://elmlang.herokuapp.com/) and [the elm-discuss mailing list](https://groups.google.com/forum/?fromgroups#!forum/elm-discuss) are a great way to get in touch with other developers learning and using elm. You can also out http://elm-lang.org/community for more ways to get involved in the elm community!
+  - [The official Elm guide](https://guide.elm-lang.org/) is a great resource, and gives a great rundown of some of the more complicated parts of the language.
+  - [The elm-tutorial project](https://www.gitbook.com/book/sporto/elm-tutorial/details) is an incredibly in-depth tutorial on building a single page app using Elm.
+  - [The Elm Slack group](http://elmlang.herokuapp.com/) and [the elm-discuss mailing list](https://groups.google.com/forum/?fromgroups#!forum/elm-discuss) are a great way to get in touch with other developers learning and using Elm. You can also out http://elm-lang.org/community for more ways to get involved in the Elm community!
 
-But more than anything, the best way to learn elm is write more elm! You now know more than enough to write complex and rich front end applications in the language, and you'll pick nuances of the language as you go. Good luck!
+But more than anything, the best way to learn Elm is write more Elm! You now know more than enough to write complex and rich front end applications in the language, and you'll pick nuances of the language as you go. Good luck!

--- a/Emojification.md
+++ b/Emojification.md
@@ -22,13 +22,13 @@ Spoiler alert: Emojis are complicated! And created a decoder-ring-style translat
 
 We'll need to use that code to convert the display text from plain text to emojis. But how do we pull that code in to our `View.elm` file?
 
-That's where the elm **module** system comes into play. Modules are simply collections of related functions. They are helpful for encapsulating behavior, and for providing clear boundaries between libraries. Let's take a look at the first few lines of `EmojiConverter.elm`:
+That's where the Elm **module** system comes into play. Modules are simply collections of related functions. They are helpful for encapsulating behavior, and for providing clear boundaries between libraries. Let's take a look at the first few lines of `EmojiConverter.elm`:
 
 ```elm
 module EmojiConverter exposing (textToEmoji, emojiToText, supportedEmojis)
 ```
 
-Like all elm files, `EmojiConverter.elm` starts off by telling us what module it defines. In other files, we'll be able to call it's functions by using the `EmojiConverter` namespace, in the same way we use the `Html` or `List` namespaces.
+Like all Elm files, `EmojiConverter.elm` starts off by telling us what module it defines. In other files, we'll be able to call it's functions by using the `EmojiConverter` namespace, in the same way we use the `Html` or `List` namespaces.
 
 This line also tells us the public API for the `EmojiConverter` module — regardless of what else is defined in this file, other files can, at most, access the three functions defined above. We can make some guesses as to purpose and method signature for these methods, based on their names. In this case, the `textToEmoji` function seems like exactly what we are looking for.
 
@@ -58,7 +58,7 @@ But it is:
     String -> String
 ```
 
-This error might seem like gibberish at first, but stay strong — elm error messages are very good at telling you exactly what you need to know. In this case, it seems that, instead of passing `HTML.text` a string to render, we are passing it a function that takes a string and returns a string. In elm-land, that often means that you passed too few arguments into a function — if a function takes two arguments, and you only provided it one, it will return a **partially-applied function** that still needs one more argument!
+This error might seem like gibberish at first, but stay strong — Elm error messages are very good at telling you exactly what you need to know. In this case, it seems that, instead of passing `HTML.text` a string to render, we are passing it a function that takes a string and returns a string. In Elm-land, that often means that you passed too few arguments into a function — if a function takes two arguments, and you only provided it one, it will return a **partially-applied function** that still needs one more argument!
 
 As you may have guessed, it seems like we've gotten the method signature for `EmojiConverter.textToEmoji` wrong. Let's take a look at it's definition in `EmojiConverter.elm`:
 
@@ -98,7 +98,7 @@ translateText model =
     EmojiConverter.textToEmoji "😅" model.currentText
 ```
 
-Note: Type signatures are always optional in elm, but they are highly encouraged — type signatures can be a good form of documentation, and they help the compiler make educated guessed about what went wrong when your code fails to recompile. Feel free to add your own to `translateText`!
+Note: Type signatures are always optional in Elm, but they are highly encouraged — type signatures can be a good form of documentation, and they help the compiler make educated guessed about what went wrong when your code fails to recompile. Feel free to add your own to `translateText`!
 
 We can now use this method in our `View.view` function. Since it's defined in the same file as it's being used, we don't even have to use the `View` namespace. We can simply invoke it as such:
 
@@ -110,7 +110,7 @@ Recompile your code and make sure everything still works!
 
 ### <input type="checkbox"> Step 3
 
-Finally, let's pull out the hardcoded emoji key into something more readable. Since the key denotes domain-specific information about your app, the best place to put that information would be in `Model.elm`. Remember, modules in elm are simply collections of functions that are similar to each other. Just because we put a function in `Model.elm` doesn't mean it has anything to do with our model record, or with application state in general.
+Finally, let's pull out the hardcoded emoji key into something more readable. Since the key denotes domain-specific information about your app, the best place to put that information would be in `Model.elm`. Remember, modules in Elm are simply collections of functions that are similar to each other. Just because we put a function in `Model.elm` doesn't mean it has anything to do with our model record, or with application state in general.
 
 Let's create a `defaultKey` function in `Model.elm` that simply returns the "😅" emoji. Since Model.elm includes `exposing (...)` in it's definition, we don't need to explicitly whitelist our new `defaultKey` function for export — all other files can access all functions in this file if requested.
 

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -11,7 +11,7 @@
 
 ### <input type="checkbox"> Step 1
 
-Launch the elm REPL again by running the following command:
+Launch the Elm REPL again by running the following command:
 
 ```sh
 $ elm-repl
@@ -168,7 +168,7 @@ Exit the Elm REPL by typing `:exit`, or `CTRL-C`.
 Students should be able to load the repl and do basic transformations.
 
 #### Learning Goals
-Students should start mapping elm to languages they know.
+Students should start mapping Elm to languages they know.
 
 #### Structure of in-person lesson
 Teacher should walk through the lessons alongside students, live coding in the repl.

--- a/Introduction.md
+++ b/Introduction.md
@@ -1,17 +1,17 @@
 # Welcome to ElmBridge!
 
-Today, you're going to be learning elm! So exciting!
+Today, you're going to be learning Elm! So exciting!
 
 This tutorial is meant to be completed over the course of 5 hours, broken up into two chunks:
  - 1.5 hours on learning the basics of the language.
- - 3.5 hours building an elm application from scratch — specifically, an emoji translator!
+ - 3.5 hours building an Elm application from scratch — specifically, an emoji translator!
 
 By the end of this tutorial, you should:
 
-- Know what elm is, and why people use it.
+- Know what Elm is, and why people use it.
 - Be familiar with the core data structures of the language.
-- Understand the architecture of elm applications.
-- Be able to build complex, rich front-end applications in elm.
+- Understand the architecture of Elm applications.
+- Be able to build complex, rich front-end applications in Elm.
 
 Thanks for coming! Let's get started.
 
@@ -19,7 +19,7 @@ Thanks for coming! Let's get started.
 
 We're going to be working with:
 
-- The latest version of the elm language platform.
+- The latest version of the Elm language platform.
 - The terminal.
 - The text editor of your choice.
 - The browser of your choice.
@@ -28,9 +28,9 @@ At various points today, you'll also be asked to download code from GitHub, so i
 
 ### Installing Elm
 
-If you haven't done so already, follow [the official elm guide](https://guide.elm-lang.org/get_started.html) for installing the language platform.
+If you haven't done so already, follow [the official Elm guide](https://guide.elm-lang.org/get_started.html) for installing the language platform.
 
-You can verify everything is working by launching the elm REPL ([What is a REPL?](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)) from your terminal by running the following command:
+You can verify everything is working by launching the Elm REPL ([What is a REPL?](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)) from your terminal by running the following command:
 
 ```sh
 $ elm-repl

--- a/Introduction.md
+++ b/Introduction.md
@@ -1,4 +1,4 @@
-# Welcome to Elmbridge!
+# Welcome to ElmBridge!
 
 Today, you're going to be learning elm! So exciting!
 

--- a/Making It Dynamic.md
+++ b/Making It Dynamic.md
@@ -24,7 +24,7 @@ $ elm-make Main.elm --output dist/main.js
 $ open index.html
 ```
 
-You should now have a fully functional elm application running in your browser! It should look like this:
+You should now have a fully functional Elm application running in your browser! It should look like this:
 
 ![Release 0](images/release-0.png)
 
@@ -110,7 +110,7 @@ Thankfully, the skeleton already includes some styling for us. All we need to do
   <p class="center output-text emoji-size">It's happening!!!</p>
 ```
 
-In elm, the code to generate that HTML would look like this
+In Elm, the code to generate that HTML would look like this
 
 ```elm
 Html.p

--- a/Our First Full Feature.md
+++ b/Our First Full Feature.md
@@ -11,7 +11,7 @@ Note: Your code should currently [look like this](https://github.com/elmbridge/e
 
 ## Goals
 
-  - Write elm view code using HTML as a template.
+  - Write Elm view code using HTML as a template.
   - Add a new message for your application to consume.
   - Extend a type alias and fix subsequent compiler errors.
   - Use union types to store information in more literate ways.
@@ -40,7 +40,7 @@ In our case, we want to build a switch that will allow users to toggle between "
 Take a shot at translating the above HTML to Elm! Some tips if you get stuck:
   - Most `Html` methods take two arguments: a list of attributes (produced by the `Html.Attributes` and the `Html.Events` modules) followed by a list of child elements. In this case, our `div` has one child (the `label` element), which itself has four children!
   - To render plain text elements, use `Html.text`. It simply takes a string as it's argument.
-  - Compile early and often! The elm compiler will nudge you in the right direction if your syntax is off.
+  - Compile early and often! The Elm compiler will nudge you in the right direction if your syntax is off.
 
 If you get stuck, flag down an instructor to help you through it! Alternatively, you can see [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-3-part-1).
 
@@ -75,7 +75,7 @@ You need to account for the following values:
 Add a branch to cover this pattern!
 ```
 
-Helpfully, the elm compiler enforces **case exhaustiveness** – since our `Update.update` function doesn't handle our new `ToggleDirection` value, the compiler realizes that triggering that `Msg` will break our program. Let's fix it by adding another clause to our case statement, this time matching on the pattern `ToggleDirection`.
+Helpfully, the Elm compiler enforces **case exhaustiveness** – since our `Update.update` function doesn't handle our new `ToggleDirection` value, the compiler realizes that triggering that `Msg` will break our program. Let's fix it by adding another clause to our case statement, this time matching on the pattern `ToggleDirection`.
 
 ```elm
 ToggleDirection ->
@@ -119,7 +119,7 @@ In this case, the `Model` type is simply an alias for "a record with a single ke
 
 But wait, what *is* direction? In other languages, we might describe the current direction as a string, with possible values "emoji-to-text" and "text-to-emoji". We could also model it as a boolean value, perhaps renaming it `translatingTextToEmoji?`.
 
-In elm, we have a more powerful tool at our disposal: union types! We can simply create a union type that enumerates all possible values for a direction, which keeps the code readable and fault tolerant. In `Model.elm`, let's create a custom `Direction` type with two possible values:
+In Elm, we have a more powerful tool at our disposal: union types! We can simply create a union type that enumerates all possible values for a direction, which keeps the code readable and fault tolerant. In `Model.elm`, let's create a custom `Direction` type with two possible values:
 
 ```elm
 type Direction
@@ -177,4 +177,4 @@ Here's what we know:
 
 That should be enough to get you started! If you are unsure, try to compile, and follow compiler errors until everything is fixed. If you get stuck, you can see [a completed version of this feature here](https://github.com/elmbridge/elmoji-translator/releases/tag/release-3-part-2).
 
-Congratulations, you've completed your first full feature in elm!
+Congratulations, you've completed your first full feature in Elm!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Elmbridge Curriculum
+# ElmBridge Curriculum
 
-Curriculum for the Elmbridge workshop. Hosted here: https://www.gitbook.com/book/raorao/elmbridge-curriculum/details
+Curriculum for the ElmBridge workshop. Hosted here: https://www.gitbook.com/book/raorao/elmbridge-curriculum/details
 
 ## Development Setup
 

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -1,6 +1,6 @@
 # The Basic Building Blocks of Elm
 
-In this release, you'll learn how to work the the basic data structures of elm. You'll be working with a [custom application that we've written](https://github.com/elmbridge/intro-to-elm-part-1) where you'll be asked to implement some basic transformations.
+In this release, you'll learn how to work the the basic data structures of Elm. You'll be working with a [custom application that we've written](https://github.com/elmbridge/intro-to-elm-part-1) where you'll be asked to implement some basic transformations.
 
 ## Goals
 
@@ -36,7 +36,7 @@ All the code for this application lives in `Main.elm`, and everything is customi
 
 ### <input type="checkbox"> Step 2
 
-Like many languages, elm has a **String** data type to store text. In this step, you should complete all the assertions for the string section of the application. Once you're ready to get started, navigate to the `sayHello` function.
+Like many languages, Elm has a **String** data type to store text. In this step, you should complete all the assertions for the string section of the application. Once you're ready to get started, navigate to the `sayHello` function.
 
 ```elm
 sayHello friendsName =
@@ -59,11 +59,11 @@ If you get stuck, flag down an instructor! They are here to help.
 
 ### <input type="checkbox"> Step 3
 
-In elm, you can use a **List** to store a collection of elements. Unlike dynamic languages, though, Elm lists are **typed** — every element in a list must the same kind of thing. You can't have a list that stores both strings and numbers, for example.
+In Elm, you can use a **List** to store a collection of elements. Unlike dynamic languages, though, Elm lists are **typed** — every element in a list must the same kind of thing. You can't have a list that stores both strings and numbers, for example.
 
 For this step, you should complete all the `List` assertions. Some tips:
 
-- In another language, you might solve these assertions by creating an empty list, and incrementally adding things to it as you iterate over the passed-in list. That's not possible in elm — once you've declared a variable in Elm, you can never change it. You will have to use more complicated `List` functions, like `List.map`.
+- In another language, you might solve these assertions by creating an empty list, and incrementally adding things to it as you iterate over the passed-in list. That's not possible in Elm — once you've declared a variable in Elm, you can never change it. You will have to use more complicated `List` functions, like `List.map`.
 - Most common functions that operate on lists live in [the `List` module](http://package.elm-lang.org/packages/elm-lang/core/latest/List). The order of arguments to these functions may be disorienting — in functional programming languages, the convention is to have the data you are operating on be the *last* argument to a function, not the first.
 - Many of these functions consume a function. To use them, you can use an anonymous function, like this:
 
@@ -77,7 +77,7 @@ Good luck!
 
 ### <input type="checkbox"> Step 4
 
-Just like Ruby has hashes and JavaScript has objects, elm has **records** to store key-value pairs. Unlike those other languages, though, elm does not allow you to change the number of keys of a record after creation. A record with three keys always has three keys, no matter what.
+Just like Ruby has hashes and JavaScript has objects, Elm has **records** to store key-value pairs. Unlike those other languages, though, Elm does not allow you to change the number of keys of a record after creation. A record with three keys always has three keys, no matter what.
 
 Unlike strings and lists, records are a special data type that have a special syntax for getting and setting values. You can create a record like this:
 
@@ -98,4 +98,4 @@ And to update a specific attribute, you use `|` operator
 { aNewRecordAppears | key = "a new value for the specified key" }
 ```
 
-There is no `Record` module — all record functions are implemented through special syntax. You can learn more about the type in [the official elm guide on records.](http://elm-lang.org/docs/records).
+There is no `Record` module — all record functions are implemented through special syntax. You can learn more about the type in [the official Elm guide on records.](http://elm-lang.org/docs/records).

--- a/The Elm Architecture.md
+++ b/The Elm Architecture.md
@@ -6,8 +6,8 @@ In this lesson, we'll run a simple Elm application, and learn how it all fits to
 
 ## Goals
 
-  - Run your first elm application.
-  - Learn how every part of an elm application works.
+  - Run your first Elm application.
+  - Learn how every part of an Elm application works.
 
 ## Steps
 
@@ -19,7 +19,7 @@ Download the Skeleton app here: [https://github.com/elmbridge/elmoji-translator/
 $ elm-make Main.elm --output dist/main.js
 ```
 
-`elm-make` **compiles** your application — it turns your Elm code into JavaScript code that your browser can understand. The above command uses `Main.elm` as the **entry point** to your application — it compiles that file, along with any files it references, and dumps the output into a file called `main.js`. This file is loaded in `index.html`, which then kicks off your elm application using JavaScript.
+`elm-make` **compiles** your application — it turns your Elm code into JavaScript code that your browser can understand. The above command uses `Main.elm` as the **entry point** to your application — it compiles that file, along with any files it references, and dumps the output into a file called `main.js`. This file is loaded in `index.html`, which then kicks off your Elm application using JavaScript.
 
 Whenever you make a change to your code, you will have to recompile before those changes are reflected in your browser. If your code is broken in someway, `elm-make` will fail, and give you helpful error messages on what you need to fix.
 
@@ -29,7 +29,7 @@ Now run the following command to open the application in your browser:
 $ open index.html
 ```
 
-You should now have a fully functional elm application, that looks like this:
+You should now have a fully functional Elm application, that looks like this:
 
 ![Hello World](images/hello-world.gif)
 
@@ -50,7 +50,7 @@ main =
 The `main` function describes the initialization logic for your Elm application. Every entry point file requires `main` function. It consumes a record with three basic pieces of every Elm application:
 
 - **The initial `model`**, which describes the state of our application. The value of `model` will change as the user interacts with our application.
-- **The `view` function**, which is responsible for converting a `model` into HTML for elm to render to the UI. It also maps all possible user actions to the appropriate `messages`.
+- **The `view` function**, which is responsible for converting a `model` into HTML for Elm to render to the UI. It also maps all possible user actions to the appropriate `messages`.
 - **The `update` function**, which is responsible for updating the application's state based on triggered `messages`. It consumes the current application state (the `model`) a single `message`, and returns a new `model` that describes the application's new state.
 
 ![The Elm Architecture](images/elm-architecture-4.jpeg)
@@ -75,11 +75,11 @@ type alias Model =
     { text : String }
 ```
 
-We'll learn more about type aliases later in this tutorial, but for now, it's worth noting that it is simply used for convenience. It's an easy way for other elm developers to tell exactly what information is stored in your `model`.
+We'll learn more about type aliases later in this tutorial, but for now, it's worth noting that it is simply used for convenience. It's an easy way for other Elm developers to tell exactly what information is stored in your `model`.
 
 ### <input type="checkbox"> Step 4
 
-Now, let's take a look at our `view` function in `View.elm`, which is responsible for converting our `model` into HTML. Any changes between the produced HTML and the last rendered HTML will be rendered to the UI by elm.
+Now, let's take a look at our `view` function in `View.elm`, which is responsible for converting our `model` into HTML. Any changes between the produced HTML and the last rendered HTML will be rendered to the UI by Elm.
 
 ```elm
 view model =
@@ -110,9 +110,9 @@ The child div has two attributes (another `class` attribute and an `onClick` han
 
 What does `model.text` means in the context of our `view` function? This function is responsible for rendering the application's current state as HTML — and that state is stored in the `model` variable. Every time the application's state changes, this function will be called with a new `model` value — if `model.text` is different than the last time this function was called, the UI will update with new text!
 
-You may wonder how this function can be performant — every time the `model` changes, even slightly, our `view` function has to recalculate every HTML element in your application. If you have hundreds of elements, and dozens of potential changes, How does elm not collapse under the load?
+You may wonder how this function can be performant — every time the `model` changes, even slightly, our `view` function has to recalculate every HTML element in your application. If you have hundreds of elements, and dozens of potential changes, How does Elm not collapse under the load?
 
-Good news: Elm is optimized to be performant under pressure. It uses a library called [virtual-dom](https://github.com/elm-lang/virtual-dom) to ensure that the entire page doesn't have to re-render every time the application's state changes. React and Ember use similar strategies, although Elm has more tricks up it's sleeve because of it's functional nature. The exact details are out of scope for this tutorial, however — just know that you generally don't have to worry about performance when writing elm.
+Good news: Elm is optimized to be performant under pressure. It uses a library called [virtual-dom](https://github.com/elm-lang/virtual-dom) to ensure that the entire page doesn't have to re-render every time the application's state changes. React and Ember use similar strategies, although Elm has more tricks up it's sleeve because of it's functional nature. The exact details are out of scope for this tutorial, however — just know that you generally don't have to worry about performance when writing Elm.
 
 Before we move on, let's take another look at that `onClick` handler:
 
@@ -146,7 +146,7 @@ We just saw that the `ChangeText` message can be triggered in the UI when the us
 
 Either way, the new `model` will be converted to HTML, and any changed will be rendered to the UI by our `view` function.
 
-Wait, there's only one possible action tracked in our UI — why have a case statement at all?  This is convention in elm-land. As you build an application, there will be more and more kinds of `messages` to which your `update` function will have to react. Consequently, this case statement will get longer and longer to accomodate the new messages.
+Wait, there's only one possible action tracked in our UI — why have a case statement at all?  This is convention in Elm-land. As you build an application, there will be more and more kinds of `messages` to which your `update` function will have to react. Consequently, this case statement will get longer and longer to accomodate the new messages.
 
 It's worth taking a look at `Msg` type:
 
@@ -155,8 +155,8 @@ type Msg
     = ChangeText
 ```
 
-This is a **union type** declaration in elm. We'll go further into the details in a future lesson, but for right now, you can think of this as way to model `messages` in our application. The above code declares that there is exactly one acceptable value for a `message`: a value called `ChangeText`. If we wanted to add another `message`, we would have to change this declaration to include a new value for `Msg`.
+This is a **union type** declaration in Elm. We'll go further into the details in a future lesson, but for right now, you can think of this as way to model `messages` in our application. The above code declares that there is exactly one acceptable value for a `message`: a value called `ChangeText`. If we wanted to add another `message`, we would have to change this declaration to include a new value for `Msg`.
 
-Elm doesn't enforce that we use a union type called `Msg` for `messages` — we could just as easily model `messages` as strings, or numbers, or records. It is convention, however, to model data using union types whenever appropriate. Don't worry if you are somewhat lost — union types are one of the more difficult concepts to learn as a beginner to elm, and it's fine for now if they are simply magic words you know you can recite.
+Elm doesn't enforce that we use a union type called `Msg` for `messages` — we could just as easily model `messages` as strings, or numbers, or records. It is convention, however, to model data using union types whenever appropriate. Don't worry if you are somewhat lost — union types are one of the more difficult concepts to learn as a beginner to Elm, and it's fine for now if they are simply magic words you know you can recite.
 
-Now that we're done touring the basics of the elm triad, let's get building!
+Now that we're done touring the basics of the Elm triad, let's get building!


### PR DESCRIPTION
Fixes the first three proper nouns I noticed that were not capitalized according to their official spelling.