### PR TITLE
Remove leading '$' from terminal commands

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -14,7 +14,7 @@
 Launch the Elm REPL again by running the following command:
 
 ```sh
-$ elm-repl
+elm-repl
 ```
 
 Now that you are in the REPL, you can write your first Elm code! Code you should try out in the REPL is written on lines starting with `>`.

--- a/Introduction.md
+++ b/Introduction.md
@@ -33,7 +33,7 @@ If you haven't done so already, follow [the official Elm guide](https://guide.el
 You can verify everything is working by launching the Elm REPL ([What is a REPL?](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)) from your terminal by running the following command:
 
 ```sh
-$ elm-repl
+elm-repl
 ```
 
 If you see the following message, you are ready to go!

--- a/Making It Dynamic.md
+++ b/Making It Dynamic.md
@@ -20,8 +20,8 @@ We need to walk before we run, though! First, we'll make an application that sim
 Download the Skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/release-0](https://github.com/elmbridge/elmoji-translator/releases/tag/release-0) and navigate to the downloaded folder. Run the following commands to open the app in your browser:
 
 ```sh
-$ elm-make Main.elm --output dist/main.js
-$ open index.html
+elm-make Main.elm --output dist/main.js
+open index.html
 ```
 
 You should now have a fully functional Elm application running in your browser! It should look like this:
@@ -94,7 +94,7 @@ update msg model =
 once you've made the change, recompile your code by running the following:
 
 ```sh
-$ elm-make Main.elm --output dist/main.js
+elm-make Main.elm --output dist/main.js
 ```
 
 The compiler will tell you about any errors you made, or let you know that everything is working!

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Curriculum for the ElmBridge workshop. Hosted here: https://www.gitbook.com/book
 This curriculum is written using [GitBook](https://github.com/GitbookIO/gitbook). To run locally, run:
 
 ```sh
-$ npm install gitbook-cli -g
-$ gitbook serve
+npm install gitbook-cli -g
+gitbook serve
 ```
 
 ## Contributing

--- a/The Elm Architecture.md
+++ b/The Elm Architecture.md
@@ -16,7 +16,7 @@ In this lesson, we'll run a simple Elm application, and learn how it all fits to
 Download the Skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world](https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world) and navigate to the downloaded folder. Run the following command:
 
 ```sh
-$ elm-make Main.elm --output dist/main.js
+elm-make Main.elm --output dist/main.js
 ```
 
 `elm-make` **compiles** your application — it turns your Elm code into JavaScript code that your browser can understand. The above command uses `Main.elm` as the **entry point** to your application — it compiles that file, along with any files it references, and dumps the output into a file called `main.js`. This file is loaded in `index.html`, which then kicks off your Elm application using JavaScript.
@@ -26,7 +26,7 @@ Whenever you make a change to your code, you will have to recompile before those
 Now run the following command to open the application in your browser:
 
 ```sh
-$ open index.html
+open index.html
 ```
 
 You should now have a fully functional Elm application, that looks like this:


### PR DESCRIPTION
Without the `$`, it's easy to copy and paste, and clearer to beginners that the `$` is not part of the command.