### PR TITLE
Fix syntax highlighting color for function definitions

### DIFF
--- a/styles/website.css
+++ b/styles/website.css
@@ -2,3 +2,7 @@
   padding: 20px;
   background-color: #f7f7f7;
 }
+
+.hljs-title {
+  color: #4271ae !important;
+}


### PR DESCRIPTION
Fix for https://github.com/elmbridge/curriculum/issues/52

(Could probably be done without `!important` with this selector: `.book .book-body .page-wrapper .page-inner section.normal code .hljs-title` )