### PR TITLE
Record has fields, which has a name and a value

### DIFF
--- a/Choose Your Own Emoji.md
+++ b/Choose Your Own Emoji.md
@@ -119,7 +119,7 @@ type DrinkOrder
 
 Apparently, there's a lot of complexity bundled up in our drink orders! In some cases, we need to know what kind of milk the customer wants, in other cases, we need to know information specific to only one kind of drink. The above data model accounts for that complexity by using tagged values — a `HotChocolate` is only a valid `DrinkOrder` if it is accompanied by a `Milk` selection, and a `BlackCoffee` relies on another union type to determine the customer's preferred brewing strategy.
 
-We could have also modeled this problem with a record, but the data would have likely been harder to follow. What would the `.milk` key on that record mean, if the customer wanted black coffee? Why would we need a `.numberOfEspressoShots` in order to make a hot chocolate?
+We could have also modeled this problem with a record, but the data would have likely been harder to follow. What would the `.milk` field on that record mean, if the customer wanted black coffee? Why would we need a `.numberOfEspressoShots` in order to make a hot chocolate?
 
 Tagged values are also helpful in preventing bad data from propagating through our system. For instance, a drink order of "single shot latte" isn't enough in the real world — if we tried to make it, we wouldn't know how what kind of milk our customer wanted. Tagged values protect us here — if we tried to use `Latte 1` in a function that was expecting something of the type `DrinkOrder`, our code would fail to compile.
 
@@ -127,7 +127,7 @@ So let's wire up our new tagged value to `Update.update`! In order:
 
 - Add the aforementioned `onClick` attribute to the `.key-selector` element.
 - Add the new `SetSelectedKey String` value to `Update.Msg`, and ensure that `Update.update` handles the new case.
-- Find a way to store the key information on the model, perhaps in a new attribute called `selectedKey`.
+- Find a way to store the key information on the model, perhaps in a new field called `selectedKey`.
 - Ensure that you the model initialization logic still works. We should start off the application with a `model.selectedKey` value of `Model.defaultKey`.
 - Implement the `SetSelectedKey String` case of `Update.update`, so that it updates the model with the correct `selectedKey`.
 
@@ -135,7 +135,7 @@ That's a lot! Work slowly, and lean on your compiler for help. If you get stuck,
 
 ### <input type="checkbox"> Step 4
 
-Now that `Update.update` consumes our new message, we need to reflect changes to the model onto the UI. First off, we need to use our new `model.selectedKey` attribute to display to the user which key is currently selected. As of now, our `renderKeys` function does not consume `model`, so it has no idea about the current state of the application. Let's change that! `renderKeys` should look like this:
+Now that `Update.update` consumes our new message, we need to reflect changes to the model onto the UI. First off, we need to use our new `model.selectedKey` field to display to the user which key is currently selected. As of now, our `renderKeys` function does not consume `model`, so it has no idea about the current state of the application. Let's change that! `renderKeys` should look like this:
 
 
 ```elm

--- a/Making It Dynamic.md
+++ b/Making It Dynamic.md
@@ -46,7 +46,7 @@ type alias Model =
     { currentText : String }
 ```
 
-For this application, the model is a record that contains a `currentText` attribute that must be a string. That's perfect for our feature — as a user inputs text into the application, we'll update the `currentText` attribute, and reflect its new value to the UI.
+For this application, the model is a record that contains a `currentText` field that must be a string. That's perfect for our feature — as a user inputs text into the application, we'll update the `currentText` field, and reflect its new value to the UI.
 
 Let's verify that user text input is mapped to a `message`. First, let's look in `View.elm`, which is much bigger than it was in the last lesson! Specifically, let's take a look at the code for input field.
 

--- a/Our First Full Feature.md
+++ b/Our First Full Feature.md
@@ -137,7 +137,7 @@ First thing's first — we need to find a way to describe the current direction 
     { currentText : String }
 ```
 
-The code above declares that `Model` is a **type alias** for a specific record structure. A type alias works a lot like a union type declaration — it also produces a new type that we can use in our program. In this case, the `Model` type is just another name for "a record with a single key called `currentText`."
+The code above declares that `Model` is a **type alias** for a specific record structure. A type alias works a lot like a union type declaration — it also produces a new type that we can use in our program. In this case, the `Model` type is just another name for "a record with a single field called `currentText`."
 
 Type aliases are helpful for making type signatures simple and readable. For example, you can see that `Model` is used in the type signature for `init`:
 
@@ -155,7 +155,7 @@ init =
     { currentText = "" }
 ```
 
-Now back to business: we'll need to extend this type alias declaration, by adding another key to the record:
+Now back to business: we'll need to extend this type alias declaration, by adding another field to the record:
 
 ```elm
  type alias Model =
@@ -183,9 +183,9 @@ Now, we can use that new type in our `Model` type alias:
     }
 ```
 
-If you try to compile right now, you should get some errors: Our code wasn't written to handle a `Model` with a `direction` attribute! See if you can figure out what's wrong and fix it.
+If you try to compile right now, you should get some errors: Our code wasn't written to handle a `Model` with a `direction` field! See if you can figure out what's wrong and fix it.
 
-Now that `Model` can describe the current translation direction, we need to change `Update.update` to correctly set the `direction` attribute when it consumes the `ToggleDirection` message.
+Now that `Model` can describe the current translation direction, we need to change `Update.update` to correctly set the `direction` field when it consumes the `ToggleDirection` message.
 
 Inside `Update.update`, we know two things – the current `Msg` we received, as well as the current state of the `model`, which includes its current `direction`. That's all the information we need – if the current `model.direction` is `EmojiToText`, `Update.update` should return a `model` with a `direction` value of `TextToEmoji`, and vice versa.
 

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -101,7 +101,7 @@ Good luck!
 
 Just like JavaScript has objects to store name-value pairs, Elm has **records**. Unlike JavaScript's objects, though, Elm treats the structure of a record as immutable. Once a record has been defined, you cannot add or remove a field, or change the type of a field.
 
-Unlike strings and lists, records are a special data type that have a special syntax for getting and setting values. You can create a record like this:
+Unlike strings and lists, records are a special data type that has a special syntax for getting and setting values. You can create a record like this:
 
 ```elm
 aNewRecordAppears =

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -99,25 +99,25 @@ Good luck!
 
 ### <input type="checkbox"> Step 5
 
-Just like Ruby has hashes and JavaScript has objects, Elm has **records** to store key-value pairs. Unlike those other languages, though, Elm treats the keys of records as immutable. Once a record has been defined, you cannot add, edit, or remove its keys.
+Just like Ruby has hashes and JavaScript has objects, Elm has **records** to store name-value pairs. Unlike those other languages, though, Elm treats the fields of records as immutable. Once a record has been defined, you cannot add or remove its fields, or change the type of a field.
 
 Unlike strings and lists, records are a special data type that have a special syntax for getting and setting values. You can create a record like this:
 
 ```elm
 aNewRecordAppears =
-  { key = "value", anotherKey = 1111 }
+  { fieldOne = "value", anotherField = 1111 }
 ```
 
 To get the value out of a record, you can use `.` syntax:
 
 ```elm
-aNewRecordAppears.key
+aNewRecordAppears.fieldOne
 ```
 
-And to update a specific attribute, you use `|` syntax:
+And to update a specific field, you use `|` syntax:
 
 ```elm
-{ aNewRecordAppears | key = "a new value for the specified key" }
+{ aNewRecordAppears | fieldOne = "a new value for the specified field" }
 ```
 
 There is no `Record` module — all record functions are implemented through special syntax. You can learn more about the type in [the official Elm guide on records](http://elm-lang.org/docs/records).

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -99,7 +99,7 @@ Good luck!
 
 ### <input type="checkbox"> Step 5
 
-Just like Ruby has hashes and JavaScript has objects, Elm has **records** to store name-value pairs. Unlike those other languages, though, Elm treats the fields of records as immutable. Once a record has been defined, you cannot add or remove its fields, or change the type of a field.
+Just like JavaScript has objects to store name-value pairs, Elm has **records**. Unlike JavaScript's objects, though, Elm treats the structure of a record as immutable. Once a record has been defined, you cannot add or remove a field, or change the type of a field.
 
 Unlike strings and lists, records are a special data type that have a special syntax for getting and setting values. You can create a record like this:
 

--- a/The Elm Architecture.md
+++ b/The Elm Architecture.md
@@ -68,7 +68,7 @@ init =
     { text = "hello world!" }
 ```
 
-As you can see, `Model.init` takes no arguments and returns a **record**, which is a key-value map with predefined keys. This particular record has a single key called `text`, with a value of `"hello world!"`. This record represents the state of our application — it is the only thing in our entire application that can change over time. As the `model` changes, the UI should change to reflect its new value.
+As you can see, `Model.init` takes no arguments and returns a **record**, which is a name-value map with predefined structure. This particular record has a single field called `text`, with a value of `"hello world!"`. This record represents the state of our application — it is the only thing in our entire application that can change over time. As the `model` changes, the UI should change to reflect its new value.
 
 It is convention to write a **type alias** to describe your application's state, and call it `Model`, like this:
 


### PR DESCRIPTION
fixes #55

consolidates record-related terminology to:

* a record has _fields_
* a field has a _name_ and a _value_
* a record's _structure_ is fixed

also removes reference to Ruby's hashes from the step that introduces Elm records.
