### PR TITLE
Adds header naming in place of Step #

### DIFF
--- a/Choose Your Own Emoji.md
+++ b/Choose Your Own Emoji.md
@@ -18,7 +18,7 @@ Note: Your code should currently [look like this](https://github.com/elmbridge/e
 
 ## Steps
 
-### Step 1
+### Adding New UI Elements
 
 As we did with our last lesson, let's start first by updating `View.elm` with our new UI elements. The eventual markup should look like this:
 
@@ -69,7 +69,7 @@ If you want to learn more, the `List` module is thoroughly documented on [packag
 
 Now, it's your turn! Add the new markup to `View.view`, with the `renderKeys` and `renderKey` helper functions. If you get stuck, you can see [a completed version of this step here](https://github.com/elmbridge/elmoji-translator/releases/tag/release-4-part-1).
 
-### Step 2
+### Displaying the Currenlty Selected Key
 
 There's one more part of the UI that we have to render — we have to display the currently selected key as selected. If we give the specified emoji `.key-selector` a class of `.is-selected`, it will display with a blue background. For now, we'll
 hard code the selected key to `Model.defaultKey`.
@@ -88,7 +88,7 @@ Html.div
 
 Once you've added that code to your `renderKey` function, you should have a working, if static, UI!
 
-### Step 3
+### Adding User Actions
 
 Now that we've updated the UI, we have to map our new user action to a message for our application to consume. Add the following line of code to your `renderKey` function, as an attribute to the element with a class of `.key-selector`:
 
@@ -133,7 +133,7 @@ So let's wire up our new tagged value to `Update.update`! In order:
 
 That's a lot! Work slowly, and lean on your compiler for help. If you get stuck, you can see [a completed version of this step here](https://github.com/elmbridge/elmoji-translator/tree/release-4-part-2).
 
-### Step 4
+### Displaying Model Values
 
 Now that `Update.update` consumes our new message, we need to reflect changes to the model onto the UI. First off, we need to use our new `model.selectedKey` field to display to the user which key is currently selected. As of now, our `renderKeys` function does not consume `model`, so it has no idea about the current state of the application. Let's change that! `renderKeys` should look like this:
 
@@ -147,7 +147,7 @@ renderKeys model =
 
 You will have to change the call site of `renderKeys` in `View.view` to match the new signature of the function, and you will have to change `renderKey` to consume a model. Once that's done, you can use `model.selectedKey` in place of `Model.defaultKey` when checking whether a key is selected. The UI should now show you which key is selected, as you click on them!
 
-### Step 5
+### Changing our Cipher
 
 And now, for the final step — we need to change our translation key based on the value of `model.selectedKey`! When you're done, your application should work like this:
 

--- a/Choose Your Own Emoji.md
+++ b/Choose Your Own Emoji.md
@@ -18,7 +18,7 @@ Note: Your code should currently [look like this](https://github.com/elmbridge/e
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 As we did with our last lesson, let's start first by updating `View.elm` with our new UI elements. The eventual markup should look like this:
 
@@ -69,7 +69,7 @@ If you want to learn more, the `List` module is thoroughly documented on [packag
 
 Now, it's your turn! Add the new markup to `View.view`, with the `renderKeys` and `renderKey` helper functions. If you get stuck, you can see [a completed version of this step here](https://github.com/elmbridge/elmoji-translator/releases/tag/release-4-part-1).
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 There's one more part of the UI that we have to render — we have to display the currently selected key as selected. If we give the specified emoji `.key-selector` a class of `.is-selected`, it will display with a blue background. For now, we'll
 hard code the selected key to `Model.defaultKey`.
@@ -88,7 +88,7 @@ Html.div
 
 Once you've added that code to your `renderKey` function, you should have a working, if static, UI!
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 Now that we've updated the UI, we have to map our new user action to a message for our application to consume. Add the following line of code to your `renderKey` function, as an attribute to the element with a class of `.key-selector`:
 
@@ -133,7 +133,7 @@ So let's wire up our new tagged value to `Update.update`! In order:
 
 That's a lot! Work slowly, and lean on your compiler for help. If you get stuck, you can see [a completed version of this step here](https://github.com/elmbridge/elmoji-translator/tree/release-4-part-2).
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 Now that `Update.update` consumes our new message, we need to reflect changes to the model onto the UI. First off, we need to use our new `model.selectedKey` field to display to the user which key is currently selected. As of now, our `renderKeys` function does not consume `model`, so it has no idea about the current state of the application. Let's change that! `renderKeys` should look like this:
 
@@ -147,7 +147,7 @@ renderKeys model =
 
 You will have to change the call site of `renderKeys` in `View.view` to match the new signature of the function, and you will have to change `renderKey` to consume a model. Once that's done, you can use `model.selectedKey` in place of `Model.defaultKey` when checking whether a key is selected. The UI should now show you which key is selected, as you click on them!
 
-### <input type="checkbox"> Step 5
+### Step 5
 
 And now, for the final step — we need to change our translation key based on the value of `model.selectedKey`! When you're done, your application should work like this:
 

--- a/Emojification.md
+++ b/Emojification.md
@@ -16,7 +16,7 @@ Your code should currently [look like this](https://github.com/elmbridge/elmoji-
 
 ## Steps
 
-### Step 1
+### Emoji Converter
 
 Spoiler alert: Emojis are complicated! And creating a [decoder-ring-style][secret decoder rings] translator between plain text and emojis is no small feat. Thankfully, one of your teammates has already written an emoji converter library for you to use, so you don't have to deal with that complexity! The code is already in your skeleton, in `EmojiConverter.elm`.
 
@@ -100,7 +100,7 @@ Html.p
 
 Recompile the code, refresh your browser, and you should be in business!
 
-### Step 2
+### Our First Refactor
 
 While this solution works, I'd argue that the code has become harder to follow. Let's refactor!
 
@@ -121,7 +121,7 @@ Html.text (translateText model)
 
 Recompile your code and make sure everything still works!
 
-### Step 3
+### Emoji Key
 
 Finally, let's pull out the hard-coded emoji key into something more readable. Since the key denotes domain-specific information about your app, the best place to put that information would be in `Model.elm`. Remember, modules in Elm are simply collections of functions that are similar to each other. Just because we put a function in `Model.elm` doesn't mean it has anything to do with our model record, or with application state in general.
 

--- a/Emojification.md
+++ b/Emojification.md
@@ -16,7 +16,7 @@ Your code should currently [look like this](https://github.com/elmbridge/elmoji-
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 Spoiler alert: Emojis are complicated! And creating a [decoder-ring-style][secret decoder rings] translator between plain text and emojis is no small feat. Thankfully, one of your teammates has already written an emoji converter library for you to use, so you don't have to deal with that complexity! The code is already in your skeleton, in `EmojiConverter.elm`.
 
@@ -100,7 +100,7 @@ Html.p
 
 Recompile the code, refresh your browser, and you should be in business!
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 While this solution works, I'd argue that the code has become harder to follow. Let's refactor!
 
@@ -121,7 +121,7 @@ Html.text (translateText model)
 
 Recompile your code and make sure everything still works!
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 Finally, let's pull out the hard-coded emoji key into something more readable. Since the key denotes domain-specific information about your app, the best place to put that information would be in `Model.elm`. Remember, modules in Elm are simply collections of functions that are similar to each other. Just because we put a function in `Model.elm` doesn't mean it has anything to do with our model record, or with application state in general.
 

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -9,7 +9,7 @@
 
 ## Steps
 
-### Step 1
+### REPL
 
 Launch the Elm REPL again by running the following command:
 
@@ -35,7 +35,7 @@ strings, numbers, and simple mathematical expressions:
 16 : number
 ```
 
-### Step 2
+### Variables
 
 You can define and refer to variables:
 
@@ -48,7 +48,7 @@ You can define and refer to variables:
 8 : number
 ```
 
-### Step 3
+### Strings
 
 You can concatenate strings using the `++` operator:
 
@@ -62,7 +62,7 @@ You can concatenate strings using the `++` operator:
 "Hello, Anna!" : String
 ```
 
-### Step 4
+### Error Messages
 
 If you try to perform operations that don't make sense, Elm will try to tell you
 what's wrong:
@@ -91,7 +91,7 @@ acceptable on its own, I assume it is "correct" in subsequent checks. So the
 problem may actually be in how the left and right arguments interact.
 ```
 
-### Step 5
+### Functions
 
 To call a function in Elm, you simply type the name of the function and any parameters you want to pass, separated by spaces.  No parentheses or commas are necessary.
 
@@ -111,7 +111,7 @@ To disambiguate order of operations, use parentheses.
 14 : Int
 ```
 
-### Step 6
+### The String Module
 
 Let's use some functions from the [`String` module](http://package.elm-lang.org/packages/elm-lang/core/latest/String).
 
@@ -133,7 +133,7 @@ Then any function we want to use is namespaced under `String`:
 "Apple -- Apricot -- Avocado" : String
 ```
 
-### Step 7
+### Defining our own Functions
 
 Now let's define and use our own functions.
 
@@ -158,7 +158,7 @@ The arrows point to the return value.  Generally, the rightmost type is the retu
 "Hello, Janice" : String
 ```
 
-### Step 8
+### All done!
 
 Exit the Elm REPL by typing `:exit`, or `CTRL-D`.
 

--- a/Getting Started.md
+++ b/Getting Started.md
@@ -9,7 +9,7 @@
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 Launch the Elm REPL again by running the following command:
 
@@ -35,7 +35,7 @@ strings, numbers, and simple mathematical expressions:
 16 : number
 ```
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 You can define and refer to variables:
 
@@ -48,7 +48,7 @@ You can define and refer to variables:
 8 : number
 ```
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 You can concatenate strings using the `++` operator:
 
@@ -62,7 +62,7 @@ You can concatenate strings using the `++` operator:
 "Hello, Anna!" : String
 ```
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 If you try to perform operations that don't make sense, Elm will try to tell you
 what's wrong:
@@ -91,7 +91,7 @@ acceptable on its own, I assume it is "correct" in subsequent checks. So the
 problem may actually be in how the left and right arguments interact.
 ```
 
-### <input type="checkbox"> Step 5
+### Step 5
 
 To call a function in Elm, you simply type the name of the function and any parameters you want to pass, separated by spaces.  No parentheses or commas are necessary.
 
@@ -111,7 +111,7 @@ To disambiguate order of operations, use parentheses.
 14 : Int
 ```
 
-### <input type="checkbox"> Step 6
+### Step 6
 
 Let's use some functions from the [`String` module](http://package.elm-lang.org/packages/elm-lang/core/latest/String).
 
@@ -133,7 +133,7 @@ Then any function we want to use is namespaced under `String`:
 "Apple -- Apricot -- Avocado" : String
 ```
 
-### <input type="checkbox"> Step 7
+### Step 7
 
 Now let's define and use our own functions.
 
@@ -158,12 +158,12 @@ The arrows point to the return value.  Generally, the rightmost type is the retu
 "Hello, Janice" : String
 ```
 
-### <input type="checkbox"> Step 8
+### Step 8
 
 Exit the Elm REPL by typing `:exit`, or `CTRL-D`.
 
 
-### <input type="checkbox"> **Bonus!**
+### **Bonus!**
 
 You may have noticed that all the types began with a capital letter (`String`, `Float`, `Int`) except for one (`number`). In general, you can remember that all types are capital but variables are lowercase. `number` in these cases is a special variable type saying the value can act as an `Int` or a `Float`. An example:
 

--- a/Making It Dynamic.md
+++ b/Making It Dynamic.md
@@ -15,7 +15,7 @@ We need to walk before we run, though! First, we'll make an application that sim
 
 ## Steps
 
-### Step 1
+### Skeleton Setup
 
 Download the Skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/release-0](https://github.com/elmbridge/elmoji-translator/releases/tag/release-0) and navigate to the downloaded folder. Start `elm-reactor` in your terminal:
 
@@ -27,7 +27,7 @@ And then go to [http://localhost:8000/Main.elm](http://localhost:8000/Main.elm) 
 
 ![Release 0](images/release-0.png)
 
-### Step 2
+### Updating the Model
 
 As you may have already noticed, however, this Elm application doesn't *do* anything. While you can enter text on the page, the application seems to ignore it.
 
@@ -94,7 +94,7 @@ Once you've made the change, go back to your web browser (to [http://localhost:8
 
 If there are any errors from the compiler, `elm-reactor` will show them to you.  If there aren't any errors, you will see the updated application!
 
-### Step 3
+### Adding to the View
 
 Great, so we're now updating the model every time the user inputs text into our application. However, that's only half the battle — we still need to display the application's `currentText` back to the user!
 
@@ -117,7 +117,7 @@ Note: `Html.text` is a special kind of `Html` function, that produces a plain-te
 
 Insert the above code into the `View.view` function, as a list element after the div with a class of `.input-field`. Once you think you have it, recompile your code to see if it worked.
 
-### Step 4
+### Displaying Model Values
 
 We don't want the text to always be `It's happening!`, though. Instead, the text of the paragraph node should reflect the `currentText` of the current model. As the model changes, this paragraph node should change as well.
 

--- a/Making It Dynamic.md
+++ b/Making It Dynamic.md
@@ -15,7 +15,7 @@ We need to walk before we run, though! First, we'll make an application that sim
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 Download the Skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/release-0](https://github.com/elmbridge/elmoji-translator/releases/tag/release-0) and navigate to the downloaded folder. Start `elm-reactor` in your terminal:
 
@@ -27,7 +27,7 @@ And then go to [http://localhost:8000/Main.elm](http://localhost:8000/Main.elm) 
 
 ![Release 0](images/release-0.png)
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 As you may have already noticed, however, this Elm application doesn't *do* anything. While you can enter text on the page, the application seems to ignore it.
 
@@ -94,7 +94,7 @@ Once you've made the change, go back to your web browser (to [http://localhost:8
 
 If there are any errors from the compiler, `elm-reactor` will show them to you.  If there aren't any errors, you will see the updated application!
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 Great, so we're now updating the model every time the user inputs text into our application. However, that's only half the battle — we still need to display the application's `currentText` back to the user!
 
@@ -117,7 +117,7 @@ Note: `Html.text` is a special kind of `Html` function, that produces a plain-te
 
 Insert the above code into the `View.view` function, as a list element after the div with a class of `.input-field`. Once you think you have it, recompile your code to see if it worked.
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 We don't want the text to always be `It's happening!`, though. Instead, the text of the paragraph node should reflect the `currentText` of the current model. As the model changes, this paragraph node should change as well.
 

--- a/Our First Full Feature.md
+++ b/Our First Full Feature.md
@@ -18,7 +18,7 @@ Note: Your code should currently [look like this](https://github.com/elmbridge/e
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
  First, let's start in `View.elm`, where we'll map user actions in the UI to messages for our application to consume.
 
@@ -44,7 +44,7 @@ Take a shot at translating the above HTML to Elm and update the `View.view` func
 
 If you get stuck, flag down a TA or instructor to help you through it! Alternatively, you can see [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-3-part-1).
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 Now that we have a working lever, we need to wire it up to our `Update.update` function! Let's look at our `Update.elm` file, and see what messages our `Update.update` function can currently consume.
 
@@ -132,7 +132,7 @@ Html.Events.onClick Update.ToggleDirection
 
 Compile, and make sure nothing is broken! If you want, you can see [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-3-part-1).
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 When our `Update.update` function receives a `ToggleDirection` message and the current `model`, it should return a new, changed `model`:
 
@@ -213,7 +213,7 @@ ToggleDirection ->
 
 Implement the above code in `Update.update`, and make sure it compiles!
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 Now to the final part of the feature: We need to reflect changes to the model in the UI!
 

--- a/Our First Full Feature.md
+++ b/Our First Full Feature.md
@@ -18,7 +18,7 @@ Note: Your code should currently [look like this](https://github.com/elmbridge/e
 
 ## Steps
 
-### Step 1
+### Adding User Interfaces
 
  First, let's start in `View.elm`, where we'll map user actions in the UI to messages for our application to consume.
 
@@ -44,7 +44,7 @@ Take a shot at translating the above HTML to Elm and update the `View.view` func
 
 If you get stuck, flag down a TA or instructor to help you through it! Alternatively, you can see [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-3-part-1).
 
-### Step 2
+### Wiring in User Actions
 
 Now that we have a working lever, we need to wire it up to our `Update.update` function! Let's look at our `Update.elm` file, and see what messages our `Update.update` function can currently consume.
 
@@ -132,7 +132,7 @@ Html.Events.onClick Update.ToggleDirection
 
 Compile, and make sure nothing is broken! If you want, you can see [a working solution here](https://github.com/elmbridge/elmoji-translator/tree/release-3-part-1).
 
-### Step 3
+### Expanding the Model
 
 When our `Update.update` function receives a `ToggleDirection` message and the current `model`, it should return a new, changed `model`:
 
@@ -213,7 +213,7 @@ ToggleDirection ->
 
 Implement the above code in `Update.update`, and make sure it compiles!
 
-### Step 4
+### Displaying Model Values
 
 Now to the final part of the feature: We need to reflect changes to the model in the UI!
 

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -9,7 +9,7 @@ In this lesson, you'll learn how to work with the basic data structures of Elm. 
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 Get a copy of the [elm-basics](https://github.com/elmbridge/elm-basics) code:
 
@@ -32,7 +32,7 @@ You should see something like this:
 
 This application contains a series of unimplemented functions designed to teach you about the basic data structures of Elm. All the functions that you need to implement live in `Main.elm`. By default, you'll see some work-in-progress emojis, and when you successfully implement a function, you'll see a heart.  But if you'd like to customize the emojis or the colors, you can do so in `Style.elm`.  When you're done poking around, go back to `Main.elm` to start the exercises.
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 Like many languages, Elm has a **String** data type to store text. In this step, you should complete all the unimplemented functions for the string section of the application. Once you're ready to get started, navigate to the `sayHello` function.
 
@@ -54,7 +54,7 @@ String.right 1 someStringVariable
 
 If you get stuck, flag down an instructor! They are here to help.
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 Elm has all the traditional structures for conditional logic, including `if`, `else`, `case`, and the `==`, `<`, `>`, `&&`, and `||` operators. (Note: the "not equal" operator is a non-standard `/=`.) Here's what that looks like in practice:
 
@@ -79,7 +79,7 @@ Elm enforces that all branches of an `if` or `case` expression must return the s
 
 Take a shot at completing the assertions for `if` expressions!
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 In Elm, you can use a **List** to store a collection of elements. Unlike dynamic languages, though, Elm lists are **typed** — every element in a list must be the same kind of thing. You can't have a list that stores both strings and numbers, for example.
 
@@ -97,7 +97,7 @@ Note: the value after the `\` is the input to the function, while whatever is af
 
 Good luck!
 
-### <input type="checkbox"> Step 5
+### Step 5
 
 Just like JavaScript has objects to store name-value pairs, Elm has **records**. Unlike JavaScript's objects, though, Elm treats the structure of a record as immutable. Once a record has been defined, you cannot add or remove a field, or change the type of a field.
 

--- a/The Basic Building Blocks of Elm.md
+++ b/The Basic Building Blocks of Elm.md
@@ -9,7 +9,7 @@ In this lesson, you'll learn how to work with the basic data structures of Elm. 
 
 ## Steps
 
-### Step 1
+### Elm Basics Exercises
 
 Get a copy of the [elm-basics](https://github.com/elmbridge/elm-basics) code:
 
@@ -32,7 +32,7 @@ You should see something like this:
 
 This application contains a series of unimplemented functions designed to teach you about the basic data structures of Elm. All the functions that you need to implement live in `Main.elm`. By default, you'll see some work-in-progress emojis, and when you successfully implement a function, you'll see a heart.  But if you'd like to customize the emojis or the colors, you can do so in `Style.elm`.  When you're done poking around, go back to `Main.elm` to start the exercises.
 
-### Step 2
+### Working with Strings
 
 Like many languages, Elm has a **String** data type to store text. In this step, you should complete all the unimplemented functions for the string section of the application. Once you're ready to get started, navigate to the `sayHello` function.
 
@@ -54,7 +54,7 @@ String.right 1 someStringVariable
 
 If you get stuck, flag down an instructor! They are here to help.
 
-### Step 3
+### Conditional Logic
 
 Elm has all the traditional structures for conditional logic, including `if`, `else`, `case`, and the `==`, `<`, `>`, `&&`, and `||` operators. (Note: the "not equal" operator is a non-standard `/=`.) Here's what that looks like in practice:
 
@@ -79,7 +79,7 @@ Elm enforces that all branches of an `if` or `case` expression must return the s
 
 Take a shot at completing the assertions for `if` expressions!
 
-### Step 4
+### Lists
 
 In Elm, you can use a **List** to store a collection of elements. Unlike dynamic languages, though, Elm lists are **typed** — every element in a list must be the same kind of thing. You can't have a list that stores both strings and numbers, for example.
 
@@ -97,7 +97,7 @@ Note: the value after the `\` is the input to the function, while whatever is af
 
 Good luck!
 
-### Step 5
+### Records
 
 Just like JavaScript has objects to store name-value pairs, Elm has **records**. Unlike JavaScript's objects, though, Elm treats the structure of a record as immutable. Once a record has been defined, you cannot add or remove a field, or change the type of a field.
 

--- a/The Elm Architecture.md
+++ b/The Elm Architecture.md
@@ -11,7 +11,7 @@ In this lesson, we'll run a simple Elm application and learn how it all fits tog
 
 ## Steps
 
-### <input type="checkbox"> Step 1
+### Step 1
 
 Download the skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world](https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world), navigate to the downloaded folder in your terminal, and run the following command:
 
@@ -33,7 +33,7 @@ You should now have a fully functional Elm application, that looks like this:
 
 ![Hello World](images/hello-world.gif)
 
-### <input type="checkbox"> Step 2
+### Step 2
 
 So how does any of this work? Let's start with `Main.elm`, which (by convention) is the entry point to an Elm application.
 
@@ -59,7 +59,7 @@ But wait, didn't we say that a value can never change in Elm? What's exactly cha
 
 The initial `model`, `view` function, and `update` function together form a **triad** that is required in every Elm application. For more complicated programs, a few other pieces are required — however, for this session, we'll focus on the core triad.
 
-### <input type="checkbox"> Step 3
+### Step 3
 
 Let's investigate each of these pieces one by one. First, let's check out the `init` function in `Model.elm` to see what the initial state of our application is.
 
@@ -79,7 +79,7 @@ type alias Model =
 
 We'll learn more about type aliases later in this tutorial, but for now, it's worth noting that it is simply used for convenience. It's an easy way for other Elm developers to tell exactly what information is stored in your `model`.
 
-### <input type="checkbox"> Step 4
+### Step 4
 
 Now, let's take a look at our `view` function in `View.elm`, which is responsible for converting our `model` into HTML. Any changes between the produced HTML and the last rendered HTML will be rendered to the UI by Elm.
 
@@ -135,7 +135,7 @@ This line of code is key to our application — it maps a potential user action 
 There are lots of potential user actions defined in the [`Html.Events`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html-Events) module — as with JavaScript, you can track when a user clicks an element, presses a key, or submits a form. If you don't map these user actions to a `message`, however, they will be ignored by your application.
 
 
-### <input type="checkbox"> Step 5
+### Step 5
 
 Let's return to the question of change we saved for later when we were looking at `init`: What does it mean when we say `model` changes? Let's take another look at our diagram:
 

--- a/The Elm Architecture.md
+++ b/The Elm Architecture.md
@@ -11,7 +11,7 @@ In this lesson, we'll run a simple Elm application and learn how it all fits tog
 
 ## Steps
 
-### Step 1
+### The Development Environment
 
 Download the skeleton app here: [https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world](https://github.com/elmbridge/elmoji-translator/releases/tag/hello-world), navigate to the downloaded folder in your terminal, and run the following command:
 
@@ -33,7 +33,7 @@ You should now have a fully functional Elm application, that looks like this:
 
 ![Hello World](images/hello-world.gif)
 
-### Step 2
+### Elm Wiring
 
 So how does any of this work? Let's start with `Main.elm`, which (by convention) is the entry point to an Elm application.
 
@@ -59,7 +59,7 @@ But wait, didn't we say that a value can never change in Elm? What's exactly cha
 
 The initial `model`, `view` function, and `update` function together form a **triad** that is required in every Elm application. For more complicated programs, a few other pieces are required — however, for this session, we'll focus on the core triad.
 
-### Step 3
+### On Initializing the Application
 
 Let's investigate each of these pieces one by one. First, let's check out the `init` function in `Model.elm` to see what the initial state of our application is.
 
@@ -79,7 +79,7 @@ type alias Model =
 
 We'll learn more about type aliases later in this tutorial, but for now, it's worth noting that it is simply used for convenience. It's an easy way for other Elm developers to tell exactly what information is stored in your `model`.
 
-### Step 4
+### On the Application View
 
 Now, let's take a look at our `view` function in `View.elm`, which is responsible for converting our `model` into HTML. Any changes between the produced HTML and the last rendered HTML will be rendered to the UI by Elm.
 
@@ -135,7 +135,7 @@ This line of code is key to our application — it maps a potential user action 
 There are lots of potential user actions defined in the [`Html.Events`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html-Events) module — as with JavaScript, you can track when a user clicks an element, presses a key, or submits a form. If you don't map these user actions to a `message`, however, they will be ignored by your application.
 
 
-### Step 5
+### On the Application Model
 
 Let's return to the question of change we saved for later when we were looking at `init`: What does it mean when we say `model` changes? Let's take another look at our diagram:
 


### PR DESCRIPTION
Updates all Curriculum section headers to describe their contents.

Motivation: provide signaling about what each section is about ahead of time, and make it easier for students to reference previous sections/scan for past materials.

I'm very open to alternate suggestions here.